### PR TITLE
Parallelize belief loading across simulations

### DIFF
--- a/polygraphs/analysis/belief_processor.py
+++ b/polygraphs/analysis/belief_processor.py
@@ -1,3 +1,6 @@
+import os
+from concurrent.futures import ThreadPoolExecutor
+
 import pandas as pd  # Importing pandas library for data manipulation
 import h5py  # Importing h5py library for working with HDF5 files
 
@@ -44,16 +47,34 @@ class Beliefs:
     This class provides an iterator and get item to access beliefs
     """
 
-    def __init__(self, dataframe, belief_processor, graphs):
+    def __init__(
+        self,
+        dataframe,
+        belief_processor,
+        graphs,
+        parallel=True,
+        max_workers=None,
+    ):
         self.hd5_file_path = dataframe["hd5_file_path"]
         self.belief_processor = belief_processor
         self.graphs = graphs
         self.beliefs = [None] * len(dataframe)
+        self.parallel = parallel and len(self.beliefs) > 1
+        self.max_workers = max_workers or min(32, (os.cpu_count() or 1) + 4)
+        self._futures = None
         self.index = 0
 
+        if self.parallel:
+            self._executor = ThreadPoolExecutor(max_workers=self.max_workers)
+            self._futures = [
+                self._executor.submit(self._load_beliefs, idx)
+                for idx in range(len(self.beliefs))
+            ]
+        else:
+            self._executor = None
+
     def __getitem__(self, index):
-        if index > len(self.beliefs):
-            raise IndexError("Simulation index out of range")
+        self._check_index(index)
         return self.get(index)
 
     def __len__(self):
@@ -71,14 +92,25 @@ class Beliefs:
         return value
 
     def get(self, index):
+        self._check_index(index)
+
         # Return a saved beliefs dataframe using its index or load from file
         if self.beliefs[index] is not None:
             return self.beliefs[index]
-        elif index < len(self.beliefs):
-            self.beliefs[index] = self.belief_processor.get_beliefs(
-                self.hd5_file_path[index],
-                self.graphs[index],
-            )
+
+        if self._futures is not None:
+            self.beliefs[index] = self._futures[index].result()
             return self.beliefs[index]
-        else:
+
+        self.beliefs[index] = self._load_beliefs(index)
+        return self.beliefs[index]
+
+    def _check_index(self, index):
+        if index < 0 or index >= len(self.beliefs):
             raise IndexError("Simulation index out of range")
+
+    def _load_beliefs(self, index):
+        return self.belief_processor.get_beliefs(
+            self.hd5_file_path[index],
+            self.graphs[index],
+        )


### PR DESCRIPTION
### Motivation
- Loading beliefs from many HDF5 simulation files is slow when done sequentially, so concurrent loading is required to improve throughput. 

### Description
- Added `ThreadPoolExecutor`-based parallel loading to the `Beliefs` class and imported `os` and `ThreadPoolExecutor` in `polygraphs/analysis/belief_processor.py`.
- Introduced new constructor parameters `parallel` and `max_workers` and enable parallel mode only when there is more than one simulation.
- Pre-submits one load task per simulation at initialization and resolves results in `get()` via stored futures, while keeping a sequential fallback path that calls `_load_beliefs()`.
- Added `_check_index()` for centralized bounds validation and `_load_beliefs()` to encapsulate the per-simulation load call to `belief_processor.get_beliefs()`.

### Testing
- Ran static compilation check with `python -m py_compile polygraphs/analysis/belief_processor.py`, which succeeded.
- Attempted a runtime smoke test that imports `polygraphs` and exercises `Beliefs`, but it failed due to environment dependency issues (`ModuleNotFoundError: torchdata.datapipes` and NumPy/PyTorch compatibility warnings), so the parallel runtime behavior could not be fully validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1592bbc7c8326bbba853be7a720fc)