### PR TITLE
Parallel belief loading and environment-aware device selection

### DIFF
--- a/polygraphs/analysis/belief_processor.py
+++ b/polygraphs/analysis/belief_processor.py
@@ -1,3 +1,6 @@
+import os
+from concurrent.futures import ThreadPoolExecutor
+
 import pandas as pd  # Importing pandas library for data manipulation
 import h5py  # Importing h5py library for working with HDF5 files
 
@@ -44,16 +47,34 @@ class Beliefs:
     This class provides an iterator and get item to access beliefs
     """
 
-    def __init__(self, dataframe, belief_processor, graphs):
+    def __init__(
+        self,
+        dataframe,
+        belief_processor,
+        graphs,
+        parallel=True,
+        max_workers=None,
+    ):
         self.hd5_file_path = dataframe["hd5_file_path"]
         self.belief_processor = belief_processor
         self.graphs = graphs
         self.beliefs = [None] * len(dataframe)
+        self.parallel = parallel and len(self.beliefs) > 1
+        self.max_workers = max_workers or min(32, (os.cpu_count() or 1) + 4)
+        self._futures = None
         self.index = 0
 
+        if self.parallel:
+            self._executor = ThreadPoolExecutor(max_workers=self.max_workers)
+            self._futures = [
+                self._executor.submit(self._load_beliefs, idx)
+                for idx in range(len(self.beliefs))
+            ]
+        else:
+            self._executor = None
+
     def __getitem__(self, index):
-        if index > len(self.beliefs):
-            raise IndexError("Simulation index out of range")
+        self._check_index(index)
         return self.get(index)
 
     def __len__(self):
@@ -71,14 +92,25 @@ class Beliefs:
         return value
 
     def get(self, index):
+        self._check_index(index)
+
         # Return a saved beliefs dataframe using its index or load from file
         if self.beliefs[index] is not None:
             return self.beliefs[index]
-        elif index < len(self.beliefs):
-            self.beliefs[index] = self.belief_processor.get_beliefs(
-                self.hd5_file_path[index],
-                self.graphs[index],
-            )
+
+        if self._futures is not None:
+            self.beliefs[index] = self._futures[index].result()
             return self.beliefs[index]
-        else:
+
+        self.beliefs[index] = self._load_beliefs(index)
+        return self.beliefs[index]
+
+    def _check_index(self, index):
+        if index < 0 or index >= len(self.beliefs):
             raise IndexError("Simulation index out of range")
+
+    def _load_beliefs(self, index):
+        return self.belief_processor.get_beliefs(
+            self.hd5_file_path[index],
+            self.graphs[index],
+        )

--- a/polygraphs/hyperparameters.py
+++ b/polygraphs/hyperparameters.py
@@ -445,8 +445,16 @@ class PolyGraphHyperParameters(HyperParameters):
     def __init__(self):
         super().__init__()
 
-        # Target device
-        self.add(device="cpu")
+        # Target device (allow overriding via env var, default to GPU when available)
+        device = os.getenv("POLYGRAPHS_DEVICE")
+        if device is None:
+            try:
+                import torch  # local import to avoid hard dependency at module import time
+
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+            except Exception:  # pragma: no cover - fallback when torch is unavailable
+                device = "cpu"
+        self.add(device=device)
 
         # Operator name
         self.add(op=None)


### PR DESCRIPTION
### Motivation
- Speed up and parallelize loading of simulation beliefs to improve responsiveness when analyzing multiple runs.
- Make the default compute device adaptive and overrideable via environment to support GPU-aware execution when available.

### Description
- Add parallel loading support to `Beliefs` by introducing `parallel`, `max_workers`, a `ThreadPoolExecutor`, `_futures`, `_load_beliefs`, and `_check_index`, and by using future results in `get` for concurrent retrieval.
- Change `__init__`, `get`, and `__getitem__` in `Beliefs` to handle asynchronous preloading, lazy fallback loading, and proper index validation. 
- Add imports of `os` and `ThreadPoolExecutor` in `polygraphs/analysis/belief_processor.py` and compute a sane default for `max_workers` using `os.cpu_count()`.
- Update `PolyGraphHyperParameters` to choose the default `device` from the `POLYGRAPHS_DEVICE` environment variable or detect CUDA availability via a local `torch` import, falling back to `cpu` if detection fails.

### Testing
- Ran the project's automated test suite with `pytest -q`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1592bbc7c8326bbba853be7a720fc)