### PR TITLE
Add device selection and parallel belief loading for belief processing

### DIFF
--- a/polygraphs/analysis/belief_processor.py
+++ b/polygraphs/analysis/belief_processor.py
@@ -1,8 +1,14 @@
+import os
+from concurrent.futures import ThreadPoolExecutor
+
 import pandas as pd  # Importing pandas library for data manipulation
 import h5py  # Importing h5py library for working with HDF5 files
 
 
 class BeliefProcessor:
+    def __init__(self, device="cpu"):
+        self.device = "cuda" if device == "gpu" else device
+
     def get_beliefs(self, hd5_file_path, graph):
         # Open the HDF5 file in read mode
         with h5py.File(hd5_file_path, "r") as fp:
@@ -10,7 +16,10 @@ class BeliefProcessor:
             _keys = sorted(map(int, fp["beliefs"].keys()))
             # Initialize a list to store iteration number and corresponding beliefs
             # with the initial beliefs from the .bin file graph
-            iterations = [(0, graph.pg["ndata"]["beliefs"].tolist())]
+            initial_beliefs = graph.pg["ndata"]["beliefs"]
+            if hasattr(initial_beliefs, "to"):
+                initial_beliefs = initial_beliefs.to(device=self.device)
+            iterations = [(0, initial_beliefs.tolist())]
 
             # Iterate over each key (iteration number) in the HDF5 file
             for key in _keys:
@@ -44,16 +53,34 @@ class Beliefs:
     This class provides an iterator and get item to access beliefs
     """
 
-    def __init__(self, dataframe, belief_processor, graphs):
+    def __init__(
+        self,
+        dataframe,
+        belief_processor,
+        graphs,
+        parallel=True,
+        max_workers=None,
+    ):
         self.hd5_file_path = dataframe["hd5_file_path"]
         self.belief_processor = belief_processor
         self.graphs = graphs
         self.beliefs = [None] * len(dataframe)
+        self.parallel = parallel and len(self.beliefs) > 1
+        self.max_workers = max_workers or min(32, (os.cpu_count() or 1) + 4)
+        self._futures = None
         self.index = 0
 
+        if self.parallel:
+            self._executor = ThreadPoolExecutor(max_workers=self.max_workers)
+            self._futures = [
+                self._executor.submit(self._load_beliefs, idx)
+                for idx in range(len(self.beliefs))
+            ]
+        else:
+            self._executor = None
+
     def __getitem__(self, index):
-        if index > len(self.beliefs):
-            raise IndexError("Simulation index out of range")
+        self._check_index(index)
         return self.get(index)
 
     def __len__(self):
@@ -71,14 +98,25 @@ class Beliefs:
         return value
 
     def get(self, index):
+        self._check_index(index)
+
         # Return a saved beliefs dataframe using its index or load from file
         if self.beliefs[index] is not None:
             return self.beliefs[index]
-        elif index < len(self.beliefs):
-            self.beliefs[index] = self.belief_processor.get_beliefs(
-                self.hd5_file_path[index],
-                self.graphs[index],
-            )
+
+        if self._futures is not None:
+            self.beliefs[index] = self._futures[index].result()
             return self.beliefs[index]
-        else:
+
+        self.beliefs[index] = self._load_beliefs(index)
+        return self.beliefs[index]
+
+    def _check_index(self, index):
+        if index < 0 or index >= len(self.beliefs):
             raise IndexError("Simulation index out of range")
+
+    def _load_beliefs(self, index):
+        return self.belief_processor.get_beliefs(
+            self.hd5_file_path[index],
+            self.graphs[index],
+        )

--- a/polygraphs/hyperparameters.py
+++ b/polygraphs/hyperparameters.py
@@ -445,8 +445,16 @@ class PolyGraphHyperParameters(HyperParameters):
     def __init__(self):
         super().__init__()
 
-        # Target device
-        self.add(device="cpu")
+        # Target device (allow overriding via env var, default to GPU when available)
+        device = os.getenv("POLYGRAPHS_DEVICE")
+        if device is None:
+            try:
+                import torch  # local import to avoid hard dependency at module import time
+
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+            except Exception:  # pragma: no cover - fallback when torch is unavailable
+                device = "cpu"
+        self.add(device=device)
 
         # Operator name
         self.add(op=None)


### PR DESCRIPTION
### Motivation
- Enable explicit target device selection for belief tensors and hyperparameters to support GPU usage when available.
- Improve I/O and CPU utilization by loading multiple belief files in parallel to reduce blocking during analysis.
- Provide safer indexing and encapsulated loading logic for the `Beliefs` container to make access more robust.

### Description
- `polygraphs/analysis/belief_processor.py` now accepts a `device` on `BeliefProcessor` initialization and moves initial belief tensors to the selected device when possible, and the module imports `os` and `ThreadPoolExecutor` to support parallel loading. 
- `Beliefs` was extended with `parallel` and `max_workers` options, uses `ThreadPoolExecutor` to prefetch belief DataFrames into futures, adds `_load_beliefs` and `_check_index` helpers, and resolves futures in `get` to return loaded DataFrames. 
- `polygraphs/hyperparameters.py` now determines the default `device` from the `POLYGRAPHS_DEVICE` environment variable or auto-detects GPU availability via a local `torch` import fallback to `cpu` if unavailable, and registers the resolved `device` in the hyperparameters.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1592bbc7c8326bbba853be7a720fc)